### PR TITLE
Add netsnmp_get_agent_uptime API

### DIFF
--- a/netsnmpagent.py
+++ b/netsnmpagent.py
@@ -1210,6 +1210,12 @@ class netsnmpAgent(object):
 			}
 		return dict(myobjs)
 
+	def get_agent_uptime(self):
+		"""
+		Get the sysUpTime from the agent
+		"""
+		return libnsa.netsnmp_get_agent_uptime()
+
 	def start(self):
 		""" Starts the agent. Among other things, this means connecting
 		    to the master agent, if configured that way. """

--- a/netsnmpapi.py
+++ b/netsnmpapi.py
@@ -536,6 +536,9 @@ for f in [ libnsa.agent_check_and_process ]:
 	]
 	f.restype = ctypes.c_int
 
+for f in [ libnsa.netsnmp_get_agent_uptime ]:
+	f.restype = ctypes.c_ulong
+
 MODE_GET                                = 160 # SNMP_MSG_GET
 MODE_GET_NEXT                           = 161 # SNMP_MSG_GET_NEXT
 MODE_SET_BEGIN                          = -1  # SNMP_MSG_INTERNAL_SET_BEGIN


### PR DESCRIPTION
 - This allows the retrieval of sysUpTime which is used by many MIBs as a
   time base